### PR TITLE
エラーハンドリング

### DIFF
--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -25,7 +25,7 @@ class FolderController extends Controller
 
         // 作成したフォルダーIDで一覧に戻る
         return redirect()->route('tasks.index', [
-            'id' => $folder->id
+            'folder_id' => $folder->id
         ]);
     }
 }

--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -25,7 +25,7 @@ class FolderController extends Controller
 
         // 作成したフォルダーIDで一覧に戻る
         return redirect()->route('tasks.index', [
-            'folder_id' => $folder->id
+            'folder' => $folder->id
         ]);
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -20,7 +20,7 @@ class HomeController extends Controller
 
         // フォルダが存在していればtasks.indexビューを表示
         return redirect()->route('tasks.index', [
-            'folder_id' => $folder->id,
+            'folder' => $folder->id,
         ]);
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -20,7 +20,7 @@ class HomeController extends Controller
 
         // フォルダが存在していればtasks.indexビューを表示
         return redirect()->route('tasks.index', [
-            'id' => $folder->id,
+            'folder_id' => $folder->id,
         ]);
     }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -14,6 +14,9 @@ class TaskController extends Controller
     // URLのidをindexアクションで受け取る
     public function index(Folder $folder)
     {
+        if (Auth::user()->id !== $folder->user_id) {
+            abort(403);
+        }
         // ログインユーザーに紐づくフォルダを取得
         $folders = Auth::user()->folders()->get();
 

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -14,9 +14,6 @@ class TaskController extends Controller
     // URLのidをindexアクションで受け取る
     public function index(Folder $folder)
     {
-        if (Auth::user()->id !== $folder->user_id) {
-            abort(403);
-        }
         // ログインユーザーに紐づくフォルダを取得
         $folders = Auth::user()->folders()->get();
 

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -12,55 +12,45 @@ use Illuminate\Support\Facades\Auth;
 class TaskController extends Controller
 {
     // URLのidをindexアクションで受け取る
-    public function index(int $folder_id)
+    public function index(Folder $folder)
     {
         // ログインユーザーに紐づくフォルダを取得
         $folders = Auth::user()->folders()->get();
 
-        // 選択されたフォルダのレコードを取得
-        $current_folder = Folder::find($folder_id);
-
-        // カレントフォルダが存在しない場合は404エラーを返す
-        if (is_null($current_folder)) {
-            abort(404);
-        }
-
         // 選択されたフォルダに紐づくタスクのレコードを取得(getを忘れないよう注意)
-        $tasks = $current_folder->tasks()->get();
+        $tasks = $folder->tasks()->get();
 
         // ビューを返す
         return view('tasks/index', [
             'folders' => $folders,
-            'current_folder_id' => $current_folder,
+            'current_folder_id' => $folder->id,
             'tasks' => $tasks
         ]);
     }
 
-    public function showCreateForm(int $folder_id)
+    public function showCreateForm(Folder $folder)
     {
         return view('tasks/create', [
-            'folder_id' => $folder_id
+            'folder' => $folder->id,
         ]);
     }
 
-    public function create(int $folder_id, CreateTask $request)
+    public function create(Folder $folder, CreateTask $request)
     {
-        $current_folder = Folder::find($folder_id);
-
         $task = new Task();
         $task->title = $request->title;
         $task->due_date = $request->due_date;
 
-        // current_folderのタスクとしてテーブルに保存
-        $current_folder->tasks()->save($task);
+        // 現在のフォルダーのタスクとしてテーブルに保存
+        $folder->tasks()->save($task);
 
         // 作成したタスクの格納されているフォルダーのindexにリダイレクト
         return redirect()->route('tasks.index', [
-            'folder_id' => $current_folder->id
+            'folder' => $folder->id,
         ]);
     }
 
-    public function showEditForm(int $folder_id, int $task_id)
+    public function showEditForm(Folder $folder, int $task_id)
     {
         $task = Task::find($task_id);
 
@@ -69,7 +59,7 @@ class TaskController extends Controller
         ]);
     }
 
-    public function edit(int $folder_id, int $task_id, EditTask $request)
+    public function edit(Folder $folder, int $task_id, EditTask $request)
     {
         // DBからリクエストされたタスクを取得
         $task = Task::find($task_id);
@@ -81,7 +71,7 @@ class TaskController extends Controller
         $task->save();
 
         return redirect()->route('tasks.index', [
-            'folder_id' => $task->folder_id,
+            'folder' => $task->folder_id,
         ]);
     }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -52,6 +52,11 @@ class TaskController extends Controller
 
     public function showEditForm(Folder $folder, Task $task)
     {
+        // フォルダーのIDが編集中タスクのフォルダIDと異なる場合は404エラー
+        if ($folder->id !== $task->folder_id) {
+            abort(404);
+        }
+
         return view('tasks/edit', [
             'task' => $task,
         ]);
@@ -59,6 +64,10 @@ class TaskController extends Controller
 
     public function edit(Folder $folder, Task $task, EditTask $request)
     {
+        // フォルダーのIDが編集中タスクのフォルダIDと異なる場合は404エラー
+        if ($folder->id !== $task->folder_id) {
+            abort(404);
+        }
         // $taskにリクエストのデータを代入してsave
         $task->title = $request->title;
         $task->status = $request->status;

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -50,20 +50,15 @@ class TaskController extends Controller
         ]);
     }
 
-    public function showEditForm(Folder $folder, int $task_id)
+    public function showEditForm(Folder $folder, Task $task)
     {
-        $task = Task::find($task_id);
-
         return view('tasks/edit', [
             'task' => $task,
         ]);
     }
 
-    public function edit(Folder $folder, int $task_id, EditTask $request)
+    public function edit(Folder $folder, Task $task, EditTask $request)
     {
-        // DBからリクエストされたタスクを取得
-        $task = Task::find($task_id);
-
         // $taskにリクエストのデータを代入してsave
         $task->title = $request->title;
         $task->status = $request->status;

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -14,11 +14,16 @@ class TaskController extends Controller
     // URLのidをindexアクションで受け取る
     public function index(int $id)
     {
-        // フォルダテーブルのレコードをすべて取得
+        // ログインユーザーに紐づくフォルダを取得
         $folders = Auth::user()->folders()->get();
 
         // 選択されたフォルダのレコードを取得
         $current_folder = Folder::find($id);
+
+        // カレントフォルダが存在しない場合は404エラーを返す
+        if (is_null($current_folder)) {
+            abort(404);
+        }
 
         // 選択されたフォルダに紐づくタスクのレコードを取得(getを忘れないよう注意)
         $tasks = $current_folder->tasks()->get();

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -12,13 +12,13 @@ use Illuminate\Support\Facades\Auth;
 class TaskController extends Controller
 {
     // URLのidをindexアクションで受け取る
-    public function index(int $id)
+    public function index(int $folder_id)
     {
         // ログインユーザーに紐づくフォルダを取得
         $folders = Auth::user()->folders()->get();
 
         // 選択されたフォルダのレコードを取得
-        $current_folder = Folder::find($id);
+        $current_folder = Folder::find($folder_id);
 
         // カレントフォルダが存在しない場合は404エラーを返す
         if (is_null($current_folder)) {
@@ -36,16 +36,16 @@ class TaskController extends Controller
         ]);
     }
 
-    public function showCreateForm(int $id)
+    public function showCreateForm(int $folder_id)
     {
         return view('tasks/create', [
-            'folder_id' => $id
+            'folder_id' => $folder_id
         ]);
     }
 
-    public function create(int $id, CreateTask $request)
+    public function create(int $folder_id, CreateTask $request)
     {
-        $current_folder = Folder::find($id);
+        $current_folder = Folder::find($folder_id);
 
         $task = new Task();
         $task->title = $request->title;
@@ -56,11 +56,11 @@ class TaskController extends Controller
 
         // 作成したタスクの格納されているフォルダーのindexにリダイレクト
         return redirect()->route('tasks.index', [
-            'id' => $current_folder->id
+            'folder_id' => $current_folder->id
         ]);
     }
 
-    public function showEditForm(int $id, int $task_id)
+    public function showEditForm(int $folder_id, int $task_id)
     {
         $task = Task::find($task_id);
 
@@ -69,7 +69,7 @@ class TaskController extends Controller
         ]);
     }
 
-    public function edit(int $id, int $task_id, EditTask $request)
+    public function edit(int $folder_id, int $task_id, EditTask $request)
     {
         // DBからリクエストされたタスクを取得
         $task = Task::find($task_id);
@@ -81,7 +81,7 @@ class TaskController extends Controller
         $task->save();
 
         return redirect()->route('tasks.index', [
-            'id' => $task->folder_id,
+            'folder_id' => $task->folder_id,
         ]);
     }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -52,10 +52,8 @@ class TaskController extends Controller
 
     public function showEditForm(Folder $folder, Task $task)
     {
-        // フォルダーのIDが編集中タスクのフォルダIDと異なる場合は404エラー
-        if ($folder->id !== $task->folder_id) {
-            abort(404);
-        }
+        // checkRelationでリレーションのエラーチェック
+        $this->checkRelation($folder, $task);
 
         return view('tasks/edit', [
             'task' => $task,
@@ -64,10 +62,8 @@ class TaskController extends Controller
 
     public function edit(Folder $folder, Task $task, EditTask $request)
     {
-        // フォルダーのIDが編集中タスクのフォルダIDと異なる場合は404エラー
-        if ($folder->id !== $task->folder_id) {
-            abort(404);
-        }
+        $this->checkRelation($folder, $task);
+
         // $taskにリクエストのデータを代入してsave
         $task->title = $request->title;
         $task->status = $request->status;
@@ -77,5 +73,13 @@ class TaskController extends Controller
         return redirect()->route('tasks.index', [
             'folder' => $task->folder_id,
         ]);
+    }
+
+    private function checkRelation(Folder $folder, Task $task)
+    {
+        // フォルダーのIDが編集中タスクのフォルダIDと異なる場合は404エラー
+        if ($folder->id !== $task->folder_id) {
+            abort(404);
+        }
     }
 }

--- a/app/Policies/FolderPolicy.php
+++ b/app/Policies/FolderPolicy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class FolderPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Create a new policy instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/app/Policies/FolderPolicy.php
+++ b/app/Policies/FolderPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Models\Folder;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
@@ -10,12 +11,14 @@ class FolderPolicy
     use HandlesAuthorization;
 
     /**
-     * Create a new policy instance.
-     *
-     * @return void
+     * フォルダの閲覧権限
+     * @param User $user
+     * @param Folder $folder
+     * @return bool
      */
-    public function __construct()
+    public function view(User $user, Folder $folder)
     {
-        //
+        // ユーザーとフォルダが紐付いていれば真
+        return $user->id === $folder->user_id;
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
+use App\Models\Folder;
+use App\Policies\FolderPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -13,7 +15,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        // 'App\Models\Model' => 'App\Policies\ModelPolicy',
+        Folder::class => FolderPolicy::class,
     ];
 
     /**

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,0 +1,16 @@
+@extends('layout')
+
+@section('content')
+  <div class="container">
+    <div class="row">
+      <div class="col col-md-offset-3 col-md-6">
+        <div class="text-center">
+          <p>お探しのページにアクセスする権限がありません。</p>
+          <a href="{{ route('home') }}" class="btn">
+            ホームへ戻る
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,16 @@
+@extends('layout')
+
+@section('content')
+  <div class="container">
+    <div class="row">
+      <div class="col col-md-offset-3 col-md-6">
+        <div class="text-center">
+          <p>お探しのページは見つかりませんでした。</p>
+          <a href="{{ route('home') }}" class="btn">
+            ホームへ戻る
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,0 +1,16 @@
+@extends('layout')
+
+@section('content')
+  <div class="container">
+    <div class="row">
+      <div class="col col-md-offset-3 col-md-6">
+        <div class="text-center">
+          <p>サーバー側のエラーによりアクセスしたページは表示できませんでした。</p>
+          <a href="{{ route('home') }}" class="btn">
+            ホームへ戻る
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -18,7 +18,7 @@
                 @endforeach
               </div>
             @endif
-            <form action="{{ route('tasks.create', ['id' => $folder_id]) }}" method="POST">
+            <form action="{{ route('tasks.create', ['folder_id' => $folder_id]) }}" method="POST">
               @csrf
               <div class="form-group">
                 <label for="title">タイトル</label>

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -18,7 +18,7 @@
                 @endforeach
               </div>
             @endif
-            <form action="{{ route('tasks.create', ['folder_id' => $folder_id]) }}" method="POST">
+            <form action="{{ route('tasks.create', ['folder' => $folder]) }}" method="POST">
               @csrf
               <div class="form-group">
                 <label for="title">タイトル</label>

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -19,7 +19,7 @@
               </div>
             @endif
             <form
-                action="{{ route('tasks.edit', ['folder' => $task->folder_id, 'task_id' => $task->id]) }}"
+                action="{{ route('tasks.edit', ['folder' => $task->folder_id, 'task' => $task->id]) }}"
                 method="POST"
             >
               @csrf

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -19,7 +19,7 @@
               </div>
             @endif
             <form
-                action="{{ route('tasks.edit', ['folder_id' => $task->folder_id, 'task_id' => $task->id]) }}"
+                action="{{ route('tasks.edit', ['folder' => $task->folder_id, 'task_id' => $task->id]) }}"
                 method="POST"
             >
               @csrf

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -19,7 +19,7 @@
               </div>
             @endif
             <form
-                action="{{ route('tasks.edit', ['id' => $task->folder_id, 'task_id' => $task->id]) }}"
+                action="{{ route('tasks.edit', ['folder_id' => $task->folder_id, 'task_id' => $task->id]) }}"
                 method="POST"
             >
               @csrf

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -50,7 +50,7 @@
                   <span class="label {{ $task->status_class }}">{{ $task->status_label }}</span>
                 </td>
                 <td>{{ $task->formatted_due_date }}</td>
-                <td><a href="{{ route('tasks.edit', ['folder' => $task->folder_id, 'task_id' => $task->id]) }}">編集</a></td>
+                <td><a href="{{ route('tasks.edit', ['folder' => $task->folder_id, 'task' => $task->id]) }}">編集</a></td>
               </tr>
             @endforeach
             </tbody>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -14,7 +14,7 @@
           <div class="list-group">
             @foreach($folders as $folder)
               <a
-                  href="{{ route('tasks.index', ['id' => $folder->id]) }}"
+                  href="{{ route('tasks.index', ['folder_id' => $folder->id]) }}"
                   class="list-group-item {{ $current_folder_id === $folder->id ? 'active' : '' }}"
               >
                 {{ $folder->title }}
@@ -28,7 +28,7 @@
           <div class="panel-heading">タスク</div>
           <div class="panel-body">
             <div class="text-right">
-              <a href="{{ route('tasks.create', ['id' => $current_folder_id]) }}" class="btn btn-default btn-block">
+              <a href="{{ route('tasks.create', ['folder_id' => $current_folder_id]) }}" class="btn btn-default btn-block">
                 タスクを追加する
               </a>
             </div>
@@ -50,7 +50,7 @@
                   <span class="label {{ $task->status_class }}">{{ $task->status_label }}</span>
                 </td>
                 <td>{{ $task->formatted_due_date }}</td>
-                <td><a href="{{ route('tasks.edit', ['id' => $task->folder_id, 'task_id' => $task->id]) }}">編集</a></td>
+                <td><a href="{{ route('tasks.edit', ['folder_id' => $task->folder_id, 'task_id' => $task->id]) }}">編集</a></td>
               </tr>
             @endforeach
             </tbody>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -14,7 +14,7 @@
           <div class="list-group">
             @foreach($folders as $folder)
               <a
-                  href="{{ route('tasks.index', ['folder_id' => $folder->id]) }}"
+                  href="{{ route('tasks.index', ['folder' => $folder->id]) }}"
                   class="list-group-item {{ $current_folder_id === $folder->id ? 'active' : '' }}"
               >
                 {{ $folder->title }}
@@ -28,7 +28,7 @@
           <div class="panel-heading">タスク</div>
           <div class="panel-body">
             <div class="text-right">
-              <a href="{{ route('tasks.create', ['folder_id' => $current_folder_id]) }}" class="btn btn-default btn-block">
+              <a href="{{ route('tasks.create', ['folder' => $current_folder_id]) }}" class="btn btn-default btn-block">
                 タスクを追加する
               </a>
             </div>
@@ -50,7 +50,7 @@
                   <span class="label {{ $task->status_class }}">{{ $task->status_label }}</span>
                 </td>
                 <td>{{ $task->formatted_due_date }}</td>
-                <td><a href="{{ route('tasks.edit', ['folder_id' => $task->folder_id, 'task_id' => $task->id]) }}">編集</a></td>
+                <td><a href="{{ route('tasks.edit', ['folder' => $task->folder_id, 'task_id' => $task->id]) }}">編集</a></td>
               </tr>
             @endforeach
             </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,16 +3,16 @@
 Route::group(['middleware' => 'auth'], function () {
     Route::get('/', 'HomeController@index')->name('home');
 
-    Route::get('/folders/{id}/tasks', 'TaskController@index')->name('tasks.index');
+    Route::get('/folders/{folder_id}/tasks', 'TaskController@index')->name('tasks.index');
 
     Route::get('/folders/create', 'FolderController@showCreateForm')->name('folders.create');
     Route::post('/folders/create', 'FolderController@create');
 
-    Route::get('/folders/{id}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
-    Route::post('/folders/{id}/tasks/create', 'TaskController@create');
+    Route::get('/folders/{folder_id}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
+    Route::post('/folders/{folder_id}/tasks/create', 'TaskController@create');
 
-    Route::get('/folders/{id}/tasks/{task_id}/edit', 'TaskController@showEditForm')->name('tasks.edit');
-    Route::post('/folders/{id}/tasks/{task_id}/edit', 'TaskController@edit');
+    Route::get('/folders/{folder_id}/tasks/{task_id}/edit', 'TaskController@showEditForm')->name('tasks.edit');
+    Route::post('/folders/{folder_id}/tasks/{task_id}/edit', 'TaskController@edit');
 });
 
 Auth::routes();

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,16 +3,19 @@
 Route::group(['middleware' => 'auth'], function () {
     Route::get('/', 'HomeController@index')->name('home');
 
-    Route::get('/folders/{folder}/tasks', 'TaskController@index')->name('tasks.index');
-
     Route::get('/folders/create', 'FolderController@showCreateForm')->name('folders.create');
     Route::post('/folders/create', 'FolderController@create');
 
-    Route::get('/folders/{folder}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
-    Route::post('/folders/{folder}/tasks/create', 'TaskController@create');
+    // canミドルウェアでview認可処理にルートパラメーター{folder}を渡す
+    Route::group(['middleware' => 'can:view,folder'], function () {
+        Route::get('/folders/{folder}/tasks', 'TaskController@index')->name('tasks.index');
 
-    Route::get('/folders/{folder}/tasks/{task}/edit', 'TaskController@showEditForm')->name('tasks.edit');
-    Route::post('/folders/{folder}/tasks/{task}/edit', 'TaskController@edit');
+        Route::get('/folders/{folder}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
+        Route::post('/folders/{folder}/tasks/create', 'TaskController@create');
+
+        Route::get('/folders/{folder}/tasks/{task}/edit', 'TaskController@showEditForm')->name('tasks.edit');
+        Route::post('/folders/{folder}/tasks/{task}/edit', 'TaskController@edit');
+    });
 });
 
 Auth::routes();

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,16 +3,16 @@
 Route::group(['middleware' => 'auth'], function () {
     Route::get('/', 'HomeController@index')->name('home');
 
-    Route::get('/folders/{folder_id}/tasks', 'TaskController@index')->name('tasks.index');
+    Route::get('/folders/{folder}/tasks', 'TaskController@index')->name('tasks.index');
 
     Route::get('/folders/create', 'FolderController@showCreateForm')->name('folders.create');
     Route::post('/folders/create', 'FolderController@create');
 
-    Route::get('/folders/{folder_id}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
-    Route::post('/folders/{folder_id}/tasks/create', 'TaskController@create');
+    Route::get('/folders/{folder}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
+    Route::post('/folders/{folder}/tasks/create', 'TaskController@create');
 
-    Route::get('/folders/{folder_id}/tasks/{task_id}/edit', 'TaskController@showEditForm')->name('tasks.edit');
-    Route::post('/folders/{folder_id}/tasks/{task_id}/edit', 'TaskController@edit');
+    Route::get('/folders/{folder}/tasks/{task_id}/edit', 'TaskController@showEditForm')->name('tasks.edit');
+    Route::post('/folders/{folder}/tasks/{task_id}/edit', 'TaskController@edit');
 });
 
 Auth::routes();

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,8 +11,8 @@ Route::group(['middleware' => 'auth'], function () {
     Route::get('/folders/{folder}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
     Route::post('/folders/{folder}/tasks/create', 'TaskController@create');
 
-    Route::get('/folders/{folder}/tasks/{task_id}/edit', 'TaskController@showEditForm')->name('tasks.edit');
-    Route::post('/folders/{folder}/tasks/{task_id}/edit', 'TaskController@edit');
+    Route::get('/folders/{folder}/tasks/{task}/edit', 'TaskController@showEditForm')->name('tasks.edit');
+    Route::post('/folders/{folder}/tasks/{task}/edit', 'TaskController@edit');
 });
 
 Auth::routes();


### PR DESCRIPTION
## What
・存在しないフォルダのページを参照しようとするとオリジナルの404エラーページが表示されるようにした
・ログインユーザーに紐付いていないフォルダを参照しようとするとオリジナルの403エラーページが表示されるようにした
・サーバー側で正常なレスポンスを返せない場合にオリジナルの500エラーページが表示されるようにした

## Why
開発時に想定していない操作によって意図しないページが表示され、ユーザーが離脱する可能性を減らすため。